### PR TITLE
Switched actual and expected parameters in assert for ControllerTest.

### DIFF
--- a/service/templates/java/ControllerTest.java
+++ b/service/templates/java/ControllerTest.java
@@ -17,7 +17,7 @@ public class ${className}Test {
 
         RxHttpClient client = server.getApplicationContext().createBean(RxHttpClient.class, server.getURL());
 
-        assertEquals(client.toBlocking().exchange("/${propertyName}").status(), HttpStatus.OK);
+        assertEquals(HttpStatus.OK, client.toBlocking().exchange("/${propertyName}").status());
         server.stop();
     }
 }


### PR DESCRIPTION
The parameters passed to `asserEquals` are not in correct order.