### PR TITLE
Removed groovy feature dependency from spock feature - #322

### DIFF
--- a/base/features/groovy/feature.yml
+++ b/base/features/groovy/feature.yml
@@ -9,3 +9,5 @@ dependencies:
     coords: io.micronaut:inject-groovy
   - scope: compile
     coords: io.micronaut:runtime-groovy
+  - scope: testCompile
+    coords: io.micronaut:inject-groovy

--- a/base/features/groovy/feature.yml
+++ b/base/features/groovy/feature.yml
@@ -9,5 +9,3 @@ dependencies:
     coords: io.micronaut:inject-groovy
   - scope: compile
     coords: io.micronaut:runtime-groovy
-  - scope: testCompile
-    coords: io.micronaut:inject-groovy

--- a/base/features/spock/feature.yml
+++ b/base/features/spock/feature.yml
@@ -1,5 +1,6 @@
 description: Adds support for the Spock testing framework
-dependentFeatures:
+build:
+    plugins:
     - groovy
 dependencies:
   - scope: testCompile
@@ -7,3 +8,5 @@ dependencies:
     excludes:
       - group: org.codehaus.groovy
         module: groovy-all
+  - scope: testCompile
+    coords: io.micronaut:inject-groovy


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-core/issues/322

Adds some duplication between `groovy` and `spock` features, not sure there's any way to avoid that.