### PR TITLE
#256 use picocli for command line parsing

### DIFF
--- a/base/commands/create-bean.groovy
+++ b/base/commands/create-bean.groovy
@@ -4,11 +4,14 @@
 @Parameters(paramLabel = "BEAN-NAME", description = 'The name of the bean class to create')
 @Field String beanName
 
-@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Option(names = ['-f', '--force'], description = 'Whether to overwrite existing files')
 @Field boolean overwrite
 
-@Option(names = '-lang', description = 'The language used for the bean class (options: ${COMPLETION-CANDIDATES})')
+@Option(names = ['-l', '--lang'], description = 'The language used for the bean class (options: ${COMPLETION-CANDIDATES})')
 @Field SupportedLanguage lang
+
+@Mixin
+@Field CommonOptionsMixin autoHelp // adds help, version and other common options to the command
 
 private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {

--- a/base/commands/create-job.groovy
+++ b/base/commands/create-job.groovy
@@ -4,11 +4,14 @@
 @Parameters(paramLabel = "JOB-NAME", description = 'The name of the job class to create')
 @Field String jobName
 
-@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Option(names = ['-f', '--force'], description = 'Whether to overwrite existing files')
 @Field boolean overwrite
 
-@Option(names = '-lang', description = 'The language used for the job (options: ${COMPLETION-CANDIDATES})')
+@Option(names = ['-l', '--lang'], description = 'The language used for the job (options: ${COMPLETION-CANDIDATES})')
 @Field SupportedLanguage lang
+
+@Mixin
+@Field CommonOptionsMixin autoHelp // adds help, version and other common options to the command
 
 private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {

--- a/base/commands/create-job.groovy
+++ b/base/commands/create-job.groovy
@@ -1,43 +1,30 @@
-description("Creates a job with scheduled method") {
-    usage "mn create-job [JOB NAME]"
-    argument name: 'Job Name', description: "The name of the job class to create", required: true
-    flag name: 'force', description: "Whether to overwrite existing files"
-    flag name: 'lang', description: "The language used for the job (options: groovy, kotlin, java)"
-}
+@Command(name = 'create-job', description = 'Creates a job with scheduled method')
+@PicocliScript GroovyScriptCommand me
 
-def model = model(args[0]).forConvention("Job")
-def sourceLanguage = config.sourceLanguage
+@Parameters(paramLabel = "JOB-NAME", description = 'The name of the job class to create')
+@Field String jobName
 
-String lang = flag('lang')
-String artifactPath = "${model.packagePath}/${model.className}"
+@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Field boolean overwrite
 
-boolean overwrite = flag('force')
+@Option(names = '-lang', description = 'The language used for the job (options: ${COMPLETION-CANDIDATES})')
+@Field SupportedLanguage lang
 
-if(!lang && sourceLanguage) {
-    lang = sourceLanguage
-}
-
-if (!lang) {
+private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {
-        lang = "groovy"
+        SupportedLanguage.groovy
     } else if (file("src/main/kotlin").exists()) {
-        lang = "kotlin"
+        SupportedLanguage.kotlin
     } else {
-        lang = "java"
+        SupportedLanguage.java
     }
 }
 
-Map<String, String> langExtensions = ["groovy": "groovy", "java": "java", "kotlin": "kt"]
+def model = model(jobName).forConvention("Job")
+String artifactPath = "${model.packagePath}/${model.className}"
+lang = lang ?: SupportedLanguage.findValue(config.sourceLanguage).orElse(sniffProjectLanguage())
 
-if (!langExtensions.containsKey(lang)) {
-    error("Invalid language selection: ${lang}. Valid selections are ${langExtensions.keySet().join(', ')}")
-    return
-}
-
-String extension = langExtensions.get(lang)
-
-render template: template("${lang}/Job.${extension}"),
-        destination: file("src/main/${lang}/${artifactPath}.${extension}"),
+render template: template("${lang}/Job.${lang.extension}"),
+        destination: file("src/main/${lang}/${artifactPath}.${lang.extension}"),
         model: model,
         overwrite: overwrite
-

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     compile "io.micronaut:cli:1.0.0-SNAPSHOT"
     compile "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0"
     compile "org.yaml:snakeyaml:1.14"
-    compile "info.picocli:picocli:3.2.0"
+    compile "info.picocli:picocli:3.3.0"
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     compile "io.micronaut:cli:1.0.0-SNAPSHOT"
     compile "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0"
     compile "org.yaml:snakeyaml:1.14"
+    compile "info.picocli:picocli:3.2.0"
 }

--- a/buildSrc/src/main/groovy/io/micronaut/gradle/profile/task/ProfileCompilerTask.groovy
+++ b/buildSrc/src/main/groovy/io/micronaut/gradle/profile/task/ProfileCompilerTask.groovy
@@ -17,7 +17,6 @@
 package io.micronaut.gradle.profile.task
 
 import groovy.transform.CompileStatic
-import io.micronaut.cli.profile.commands.script.GroovyScriptCommandTransform
 import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer
@@ -30,6 +29,7 @@ import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import org.yaml.snakeyaml.DumperOptions
 import org.yaml.snakeyaml.Yaml
+import picocli.groovy.PicocliScriptASTTransformation
 
 /**
  * Compiles the classes for a profile
@@ -178,13 +178,27 @@ class ProfileCompilerTask extends AbstractCompile {
             importCustomizer.addStarImports("io.micronaut.cli.interactive.completers")
             importCustomizer.addStarImports("io.micronaut.cli.util")
             importCustomizer.addStarImports("io.micronaut.cli.codegen.model")
-            configuration.addCompilationCustomizers(importCustomizer,new ASTTransformationCustomizer(new GroovyScriptCommandTransform()))
+            importCustomizer.addStarImports("io.micronaut.cli.profile.commands")
+            importCustomizer.addStarImports("io.micronaut.cli.profile.commands.script")
+            importCustomizer.addImports("groovy.transform.Field")
+            importCustomizer.addImports("picocli.groovy.PicocliScript")
+            importCustomizer.addImports("picocli.CommandLine.Command")
+            importCustomizer.addImports("picocli.CommandLine.Mixin")
+            importCustomizer.addImports("picocli.CommandLine.Option")
+            importCustomizer.addImports("picocli.CommandLine.Parameters")
+            importCustomizer.addImports("picocli.CommandLine.ParentCommand")
+            importCustomizer.addImports("picocli.CommandLine.Spec")
+            importCustomizer.addImports("picocli.CommandLine.Unmatched")
+
+            //configuration.addCompilationCustomizers(importCustomizer,new ASTTransformationCustomizer(new GroovyScriptCommandTransform()))
+            configuration.addCompilationCustomizers(importCustomizer)
 
             for(source in groovySourceFiles) {
 
                 CompilationUnit compilationUnit = new CompilationUnit(configuration)
                 configuration.compilationCustomizers.clear()
-                configuration.compilationCustomizers.addAll(importCustomizer, new ASTTransformationCustomizer(new GroovyScriptCommandTransform()))
+                //configuration.compilationCustomizers.addAll(importCustomizer, new ASTTransformationCustomizer(new GroovyScriptCommandTransform()))
+                configuration.compilationCustomizers.addAll(importCustomizer)
                 compilationUnit.addSource(source)
                 compilationUnit.compile()
             }

--- a/service/commands/create-client.groovy
+++ b/service/commands/create-client.groovy
@@ -4,11 +4,14 @@
 @Parameters(paramLabel = "CLIENT-NAME", description = 'The name of the client to create')
 @Field String clientName
 
-@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Option(names = ['-f', '--force'], description = 'Whether to overwrite existing files')
 @Field boolean overwrite
 
-@Option(names = '-lang', description = 'The language used for the client (options: ${COMPLETION-CANDIDATES})')
+@Option(names = ['-l', '--lang'], description = 'The language used for the client (options: ${COMPLETION-CANDIDATES})')
 @Field SupportedLanguage lang
+
+@Mixin
+@Field CommonOptionsMixin autoHelp // adds help, version and other common options to the command
 
 private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {

--- a/service/commands/create-client.groovy
+++ b/service/commands/create-client.groovy
@@ -1,43 +1,30 @@
-description("Creates a client interface") {
-    usage "mn create-client [CLIENT NAME]"
-    argument name: 'Client Name', description: "The name of the client to create", required: true
-    flag name: 'force', description: "Whether to overwrite existing files"
-    flag name: 'lang', description: "The language used for the client (options: groovy, kotlin, java)"
-}
+@Command(name = 'create-client', description = 'Creates a client interface')
+@PicocliScript GroovyScriptCommand me
 
-def model = model(args[0]).forConvention("Client")
-def sourceLanguage = config.sourceLanguage
+@Parameters(paramLabel = "CLIENT-NAME", description = 'The name of the client to create')
+@Field String clientName
 
-String lang = flag('lang')
-String artifactPath = "${model.packagePath}/${model.className}"
+@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Field boolean overwrite
 
-boolean overwrite = flag('force')
+@Option(names = '-lang', description = 'The language used for the client (options: ${COMPLETION-CANDIDATES})')
+@Field SupportedLanguage lang
 
-if(!lang && sourceLanguage) {
-    lang = sourceLanguage
-}
-
-if (!lang) {
+private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {
-        lang = "groovy"
+        SupportedLanguage.groovy
     } else if (file("src/main/kotlin").exists()) {
-        lang = "kotlin"
+        SupportedLanguage.kotlin
     } else {
-        lang = "java"
+        SupportedLanguage.java
     }
 }
 
-Map<String, String> langExtensions = ["groovy": "groovy", "java": "java", "kotlin": "kt"]
+def model = model(clientName).forConvention("Client")
+String artifactPath = "${model.packagePath}/${model.className}"
+lang = lang ?: SupportedLanguage.findValue(config.sourceLanguage).orElse(sniffProjectLanguage())
 
-if (!langExtensions.containsKey(lang)) {
-    error("Invalid language selection: ${lang}. Valid selections are ${langExtensions.keySet().join(', ')}")
-    return
-}
-
-String extension = langExtensions.get(lang)
-
-render template: template("${lang}/Client.${extension}"),
-        destination: file("src/main/${lang}/${artifactPath}.${extension}"),
+render template: template("${lang}/Client.${lang.extension}"),
+        destination: file("src/main/${lang}/${artifactPath}.${lang.extension}"),
         model: model,
         overwrite: overwrite
-

--- a/service/commands/create-controller.groovy
+++ b/service/commands/create-controller.groovy
@@ -4,11 +4,14 @@
 @Parameters(paramLabel = "CONTROLLER-NAME", description = 'The name of the controller to create')
 @Field String controllerName
 
-@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Option(names = ['-f', '--force'], description = 'Whether to overwrite existing files')
 @Field boolean overwrite
 
-@Option(names = '-lang', description = 'The language used for the controller (options: ${COMPLETION-CANDIDATES})')
+@Option(names = ['-l', '--lang'], description = 'The language used for the controller (options: ${COMPLETION-CANDIDATES})')
 @Field SupportedLanguage lang
+
+@Mixin
+@Field CommonOptionsMixin autoHelp // adds help, version and other common options to the command
 
 private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {

--- a/service/commands/create-controller.groovy
+++ b/service/commands/create-controller.groovy
@@ -1,65 +1,50 @@
-description("Creates a controller and associated test") {
-    usage "mn create-controller [CONTROLLER NAME]"
-    argument name: 'Controller Name', description: "The name of the controller to create", required: true
-    flag name: 'force', description: "Whether to overwrite existing files"
-    flag name: 'lang', description: "The language used for the controller (options: groovy, kotlin, java)"
-}
+@Command(name = 'create-controller', description = 'Creates a controller and associated test')
+@PicocliScript GroovyScriptCommand me
 
-def model = model(args[0]).forConvention("Controller")
+@Parameters(paramLabel = "CONTROLLER-NAME", description = 'The name of the controller to create')
+@Field String controllerName
 
-def testFramework = config.testFramework
-def sourceLanguage = config.sourceLanguage
+@Option(names = '-force', description = 'Whether to overwrite existing files')
+@Field boolean overwrite
 
-String lang = flag('lang')
-String artifactPath = "${model.packagePath}/${model.className}"
+@Option(names = '-lang', description = 'The language used for the controller (options: ${COMPLETION-CANDIDATES})')
+@Field SupportedLanguage lang
 
-boolean overwrite = flag('force')
-
-if(!lang && sourceLanguage) {
-    lang = sourceLanguage
-}
-
-if (!lang) {
+private SupportedLanguage sniffProjectLanguage() {
     if (file("src/main/groovy").exists()) {
-        lang = "groovy"
+        SupportedLanguage.groovy
     } else if (file("src/main/kotlin").exists()) {
-        lang = "kotlin"
+        SupportedLanguage.kotlin
     } else {
-        lang = "java"
+        SupportedLanguage.java
     }
 }
 
-Map<String, String> langExtensions = ["groovy": "groovy", "java": "java", "kotlin": "kt"]
+def model = model(controllerName).forConvention("Controller")
+String artifactPath = "${model.packagePath}/${model.className}"
+lang = lang ?: SupportedLanguage.findValue(config.sourceLanguage).orElse(sniffProjectLanguage())
 
-if (!langExtensions.containsKey(lang)) {
-    error("Invalid language selection: ${lang}. Valid selections are ${langExtensions.keySet().join(', ')}")
-    return
-}
-
-String extension = langExtensions.get(lang)
-
-render template: template("${lang}/Controller.${extension}"),
-        destination: file("src/main/${lang}/${artifactPath}.${extension}"),
+render template: template("${lang}/Controller.${lang.extension}"),
+        destination: file("src/main/${lang}/${artifactPath}.${lang.extension}"),
         model: model,
         overwrite: overwrite
 
+def testFramework = config.testFramework
 String testConvention = "Test"
 
-if(testFramework == "spock") {
+if (testFramework == "spock") {
     testConvention = "Spec"
-    lang = "groovy"
-} else if(testFramework == "junit") {
-    lang = "java"
-} else if(testFramework == "spek") {
-    lang = "kotlin"
-} else if(lang == "groovy") {
+    lang = SupportedLanguage.groovy
+} else if (testFramework == "junit") {
+    lang = SupportedLanguage.java
+} else if (testFramework == "spek") {
+    lang = SupportedLanguage.kotlin
+} else if (lang == SupportedLanguage.groovy) {
     testConvention = "Spec"
 }
 
-extension = langExtensions.get(lang)
-
-render template: template("${lang}/Controller${testConvention}.${extension}"),
-        destination: file("src/test/${lang}/${artifactPath}${testConvention}.${extension}"),
+render template: template("${lang}/Controller${testConvention}.${lang.extension}"),
+        destination: file("src/test/${lang}/${artifactPath}${testConvention}.${lang.extension}"),
         model: model,
         overwrite: overwrite
 


### PR DESCRIPTION
Please take a look at this PR for https://github.com/micronaut-projects/micronaut-core/issues/256 using picocli for command line parsing.

* All `create-xxx.groovy` commands now use picocli annotations
* All `create-xxx.groovy` commands now use the `SupportedLanguage` enum defined in the cli module (see PR https://github.com/micronaut-projects/micronaut-core/pull/368)

This PR should be tested together with https://github.com/micronaut-projects/micronaut-core/pull/368.
