### PR TITLE
Adds jackson object mapper module to kotlin build.gradle dependencies

### DIFF
--- a/base/features/kotlin/feature.yml
+++ b/base/features/kotlin/feature.yml
@@ -19,4 +19,4 @@ dependencies:
   - scope: kaptTest
     coords: io.micronaut:inject-java
   - scope: runtime
-    coords: com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+
+    coords: com.fasterxml.jackson.module:jackson-module-kotlin:2.9.4.1

--- a/base/features/kotlin/feature.yml
+++ b/base/features/kotlin/feature.yml
@@ -18,3 +18,5 @@ dependencies:
     coords: io.micronaut:inject-java
   - scope: kaptTest
     coords: io.micronaut:inject-java
+  - scope: runtime
+    coords: com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+


### PR DESCRIPTION
This module for jackson makes mapping to Kotlin data classes substantially more convenient, I would recommend we add it to the kotlin profile, as anyone consuming APIs in kotlin will almost certainly appreciate it.