### PR TITLE
#474 add create-cli-app command that creates CLI app with the correct main class

### DIFF
--- a/cli/features/picocli-groovy/feature.yml
+++ b/cli/features/picocli-groovy/feature.yml
@@ -1,0 +1,7 @@
+description: Creates a picocli-based command line application using Groovy
+dependentFeatures:
+    - groovy
+    - picocli
+dependencies:
+  - scope: compile
+    coords: io.micronaut:runtime

--- a/cli/features/picocli-groovy/skeleton/src/main/groovy/@defaultPackage.path@/@project.className@Command.groovy
+++ b/cli/features/picocli-groovy/skeleton/src/main/groovy/@defaultPackage.path@/@project.className@Command.groovy
@@ -1,0 +1,28 @@
+package @defaultPackage@
+
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.ApplicationContext
+
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+
+@Command(name = '@project.name@', description = '...',
+        mixinStandardHelpOptions = true)
+class @project.className@Command implements Runnable {
+
+    @Option(names = ['-v', '--verbose'], description = '...')
+    boolean verbose
+
+    static void main(String[] args) throws Exception {
+        PicocliRunner.run(@project.className@Command.class, args)
+    }
+
+    void run() {
+        // business logic here
+        if (verbose) {
+            println "Hi!"
+        }
+    }
+}

--- a/cli/features/picocli-java/feature.yml
+++ b/cli/features/picocli-java/feature.yml
@@ -1,0 +1,9 @@
+description: Creates a picocli-based command line application using Java
+dependentFeatures:
+    - java
+    - picocli
+dependencies:
+  - scope: compile
+    coords: io.micronaut:runtime
+  - scope: testCompile
+    coords: io.micronaut:inject-java

--- a/cli/features/picocli-java/skeleton/src/main/java/@defaultPackage.path@/@project.className@Command.java
+++ b/cli/features/picocli-java/skeleton/src/main/java/@defaultPackage.path@/@project.className@Command.java
@@ -1,0 +1,28 @@
+package @defaultPackage@;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "@project.name@", description = "...",
+        mixinStandardHelpOptions = true)
+public class @project.className@Command implements Runnable {
+
+    @Option(names = {"-v", "--verbose"}, description = "...")
+    boolean verbose;
+
+    public static void main(String[] args) throws Exception {
+        PicocliRunner.run(@project.className@Command.class, args);
+    }
+
+    public void run() {
+        // business logic here
+        if (verbose) {
+            System.out.println("Hi!");
+        }
+    }
+}

--- a/cli/features/picocli-kotlin/feature.yml
+++ b/cli/features/picocli-kotlin/feature.yml
@@ -1,0 +1,9 @@
+description: Creates a picocli-based command line application using Kotlin
+dependentFeatures:
+    - kotlin
+    - picocli
+dependencies:
+  - scope: compile
+    coords: io.micronaut:runtime
+  - scope: testCompile
+    coords: io.micronaut:inject-java

--- a/cli/features/picocli-kotlin/skeleton/src/main/kotlin/@defaultPackage.path@/@project.className@Command.kt
+++ b/cli/features/picocli-kotlin/skeleton/src/main/kotlin/@defaultPackage.path@/@project.className@Command.kt
@@ -1,4 +1,4 @@
-${packageName ? 'package ' + packageName : '' }
+package @defaultPackage@
 
 import io.micronaut.configuration.picocli.PicocliRunner
 import io.micronaut.context.ApplicationContext
@@ -8,9 +8,9 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 
-@Command(name = "${propertyName}", description = ["..."],
+@Command(name = "@project.name@", description = ["..."],
         mixinStandardHelpOptions = true)
-class ${className} : Runnable {
+class @project.className@Command : Runnable {
 
     @Option(names = ["-v", "--verbose"], description = ["..."])
     private var verbose : Boolean = false
@@ -24,7 +24,7 @@ class ${className} : Runnable {
 
     companion object {
         @JvmStatic fun main(args: Array<String>) {
-            PicocliRunner.run(${className}::class.java, *args)
+            PicocliRunner.run(@project.className@Command::class.java, *args)
         }
     }
 }

--- a/cli/features/test-picocli-junit/feature.yml
+++ b/cli/features/test-picocli-junit/feature.yml
@@ -1,0 +1,11 @@
+description: Creates JUnit test for a picocli-based command line application
+dependentFeatures:
+    - junit
+    - picocli
+#dependencies:
+#  - scope: testCompile
+#    coords: io.micronaut:function-client
+#  - scope: testRuntime
+#    coords: io.micronaut:http-server-netty
+#  - scope: testRuntime
+#    coords: io.micronaut:function-web

--- a/cli/features/test-picocli-junit/skeleton/src/test/java/@defaultPackage.path@/@project.className@CommandTest.java
+++ b/cli/features/test-picocli-junit/skeleton/src/test/java/@defaultPackage.path@/@project.className@CommandTest.java
@@ -1,0 +1,28 @@
+package @defaultPackage@;
+
+import io.micronaut.configuration.picocli.PicocliRunner;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.env.Environment;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class @project.className@CommandTest {
+
+    @Test
+    public void testWithCommandLineOption() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+
+        try (ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)) {
+            String[] args = new String[] { "-v" };
+            PicocliRunner.run(@project.className@Command.class, ctx, args);
+
+            // @project.name@
+            assertTrue(baos.toString(), baos.toString().contains("Hi!"));
+        }
+    }
+}

--- a/cli/features/test-picocli-spek/feature.yml
+++ b/cli/features/test-picocli-spek/feature.yml
@@ -1,0 +1,13 @@
+description: Creates Spek test for a picocli-based command line application
+dependentFeatures:
+    - spek
+    - picocli
+#dependencies:
+#  - scope: testCompile
+#    coords: io.micronaut:function-client
+#  - scope: testCompile
+#    coords: io.micronaut:http-client
+#  - scope: testRuntime
+#    coords: io.micronaut:http-server-netty
+#  - scope: testRuntime
+#    coords: io.micronaut:function-web

--- a/cli/features/test-picocli-spek/skeleton/src/test/kotlin/@defaultPackage.path@/@project.className@CommandTest.kt
+++ b/cli/features/test-picocli-spek/skeleton/src/test/kotlin/@defaultPackage.path@/@project.className@CommandTest.kt
@@ -1,0 +1,37 @@
+package @defaultPackage@
+
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.junit.jupiter.api.Assertions.*
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+object @project.className@CommandTest : Spek({
+
+    describe("@project.name@") {
+        val ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)
+
+        on("invocation with -v") {
+            val baos = ByteArrayOutputStream()
+            System.setOut(PrintStream(baos))
+
+            val args = arrayOf("-v")
+            PicocliRunner.run(@project.className@Command::class.java, ctx, *args)
+
+            it("should display greeting") {
+                assertTrue(baos.toString().contains("Hi!"))
+            }
+        }
+
+        on("other") {
+            // add more tests...
+        }
+    }
+})

--- a/cli/features/test-picocli-spock/feature.yml
+++ b/cli/features/test-picocli-spock/feature.yml
@@ -1,0 +1,11 @@
+description: Creates Spock test for a picocli-based command line application
+dependentFeatures:
+    - spock
+    - picocli
+#dependencies:
+#  - scope: testCompile
+#    coords: io.micronaut:function-client
+#  - scope: testRuntime
+#    coords: io.micronaut:http-server-netty
+#  - scope: testRuntime
+#    coords: io.micronaut:function-web

--- a/cli/features/test-picocli-spock/skeleton/src/test/groovy/@defaultPackage.path@/@project.className@CommandSpec.groovy
+++ b/cli/features/test-picocli-spock/skeleton/src/test/groovy/@defaultPackage.path@/@project.className@CommandSpec.groovy
@@ -1,0 +1,29 @@
+package @defaultPackage@
+
+import io.micronaut.configuration.picocli.PicocliRunner
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.env.Environment
+
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class @project.className@CommandSpec extends Specification {
+
+    @Shared @AutoCleanup ApplicationContext ctx = ApplicationContext.run(Environment.CLI, Environment.TEST)
+
+    void "test @project.name@ with command line option"() {
+        given:
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(baos))
+
+        String[] args = ['-v'] as String[]
+        PicocliRunner.run(@project.className@Command, ctx, args)
+
+        expect:
+        baos.toString().contains('Hi!')
+    }
+}

--- a/cli/skeleton/gradle-build/build.gradle
+++ b/cli/skeleton/gradle-build/build.gradle
@@ -1,2 +1,8 @@
+mainClassName = "@defaultPackage@.@project.className@Command"
+applicationDefaultJvmArgs = [""]
 
-mainClassName = "@defaultPackage@.Application"
+jar {
+    manifest {
+        attributes 'Main-Class': mainClassName
+    }
+}

--- a/cli/skeleton/maven-build/pom.xml
+++ b/cli/skeleton/maven-build/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <properties>
-        <exec.mainClass>@defaultPackage@.Application</exec.mainClass>
+        <exec.mainClass>@defaultPackage@.@project.className@Command</exec.mainClass>
     </properties>
 </project>


### PR DESCRIPTION
This PR introduces a `create-cli-app` command that generates a cli project with an example command, and sets this command as the main class of the application.

This addresses https://github.com/micronaut-projects/micronaut-core/issues/474.

There is an accompanying PR (https://github.com/micronaut-projects/micronaut-core/pull/480) for the micronaut-core project.