### PR TITLE
Graal improvements

### DIFF
--- a/base/features/graal-native-image/skeleton/gradle-build/Dockerfile
+++ b/base/features/graal-native-image/skeleton/gradle-build/Dockerfile
@@ -1,17 +1,18 @@
-FROM oracle/graalvm-ce:1.0.0-rc7
+FROM oracle/graalvm-ce:1.0.0-rc8
 EXPOSE 8080
 COPY build/libs/*-all.jar @app.name@.jar
 ADD . build
 RUN java -cp @app.name@.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer 
 RUN native-image --no-server \
              --class-path @app.name@.jar \
-			 -H:ReflectionConfigurationFiles=build/reflect.json \
-			 -H:EnableURLProtocols=http \
-			 -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
-			 -H:Name=@app.name@ \
-			 -H:Class=@defaultPackage@.Application \
-			 -H:+ReportUnsupportedElementsAtRuntime \
-			 -H:+AllowVMInspection \
-			 --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
-			 --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom
+             -H:ReflectionConfigurationFiles=build/reflect.json \
+             -H:EnableURLProtocols=http \
+             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
+             -H:Name=@app.name@ \
+             -H:Class=@defaultPackage@.Application \
+             -H:+ReportUnsupportedElementsAtRuntime \
+             -H:+AllowVMInspection \
+             -H:-UseServiceLoaderFeature \
+             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
+             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom
 ENTRYPOINT ["./@app.name@"]

--- a/base/features/graal-native-image/skeleton/gradle-build/build-native-image.sh
+++ b/base/features/graal-native-image/skeleton/gradle-build/build-native-image.sh
@@ -9,5 +9,6 @@ native-image --no-server \
              -H:Class=@defaultPackage@.Application \
              -H:+ReportUnsupportedElementsAtRuntime \
              -H:+AllowVMInspection \
+             -H:-UseServiceLoaderFeature \
              --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
              --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom

--- a/base/features/graal-native-image/skeleton/gradle-build/build-native-image.sh
+++ b/base/features/graal-native-image/skeleton/gradle-build/build-native-image.sh
@@ -1,0 +1,13 @@
+./gradlew assemble
+java -cp build/libs/@app.name@-0.1-all.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
+native-image --no-server \
+             --class-path build/libs/@app.name@-0.1-all.jar \
+             -H:ReflectionConfigurationFiles=build/reflect.json \
+             -H:EnableURLProtocols=http \
+             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
+             -H:Name=@app.name@ \
+             -H:Class=@defaultPackage@.Application \
+             -H:+ReportUnsupportedElementsAtRuntime \
+             -H:+AllowVMInspection \
+             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
+             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom

--- a/base/features/graal-native-image/skeleton/gradle-build/docker-build.sh
+++ b/base/features/graal-native-image/skeleton/gradle-build/docker-build.sh
@@ -1,0 +1,3 @@
+./gradlew assemble
+docker build . -t @app.name@
+docker run --network host @app.name@

--- a/base/features/graal-native-image/skeleton/maven-build/Dockerfile
+++ b/base/features/graal-native-image/skeleton/maven-build/Dockerfile
@@ -1,17 +1,18 @@
-FROM oracle/graalvm-ce:1.0.0-rc7
+FROM oracle/graalvm-ce:1.0.0-rc8
 EXPOSE 8080
 COPY target/@app.name@-*.jar @app.name@.jar
 ADD . target
 RUN java -cp @app.name@.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer 
 RUN native-image --no-server \
              --class-path @app.name@.jar \
-			 -H:ReflectionConfigurationFiles=target/reflect.json \
-			 -H:EnableURLProtocols=http \
-			 -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
-			 -H:Name=@app.name@ \
-			 -H:Class=@defaultPackage@.Application \
-			 -H:+ReportUnsupportedElementsAtRuntime \
-			 -H:+AllowVMInspection \
-			 --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
-			 --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom
+             -H:ReflectionConfigurationFiles=target/reflect.json \
+             -H:EnableURLProtocols=http \
+             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
+             -H:Name=@app.name@ \
+             -H:Class=@defaultPackage@.Application \
+             -H:+ReportUnsupportedElementsAtRuntime \
+             -H:+AllowVMInspection \
+             -H:-UseServiceLoaderFeature \
+             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
+             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom
 ENTRYPOINT ["./@app.name@"]

--- a/base/features/graal-native-image/skeleton/maven-build/build-native-image.sh
+++ b/base/features/graal-native-image/skeleton/maven-build/build-native-image.sh
@@ -9,5 +9,6 @@ native-image --no-server \
              -H:Class=@defaultPackage@.Application \
              -H:+ReportUnsupportedElementsAtRuntime \
              -H:+AllowVMInspection \
+             -H:-UseServiceLoaderFeature \
              --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
              --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom

--- a/base/features/graal-native-image/skeleton/maven-build/build-native-image.sh
+++ b/base/features/graal-native-image/skeleton/maven-build/build-native-image.sh
@@ -1,0 +1,13 @@
+./mvnw package
+java -cp target/@app.name@-0.1.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
+native-image --no-server \
+             --class-path target/@app.name@-0.1.jar \
+             -H:ReflectionConfigurationFiles=target/reflect.json \
+             -H:EnableURLProtocols=http \
+             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
+             -H:Name=@app.name@ \
+             -H:Class=@defaultPackage@.Application \
+             -H:+ReportUnsupportedElementsAtRuntime \
+             -H:+AllowVMInspection \
+             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
+             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom

--- a/base/features/graal-native-image/skeleton/maven-build/docker-build.sh
+++ b/base/features/graal-native-image/skeleton/maven-build/docker-build.sh
@@ -1,0 +1,3 @@
+./mvnw package
+docker build . -t @app.name@
+docker run --network host @app.name@


### PR DESCRIPTION
- Add scripts to build and run Graal native image using Docker
- Bring back `build-native-image.sh` to create Graal native images without using Docker

This needs to be merged with: https://github.com/micronaut-projects/micronaut-core/pull/779