### PR TITLE
Add UTF-8 Encode to JavaCompile

### DIFF
--- a/base/features/java/skeleton/gradle-build/build.gradle
+++ b/base/features/java/skeleton/gradle-build/build.gradle
@@ -1,2 +1,4 @@
-compileJava.options.compilerArgs += '-parameters'
-compileTestJava.options.compilerArgs += '-parameters'
+tasks.withType(JavaCompile){
+    options.encoding = "UTF-8"
+    options.compilerArgs.add('-parameters')
+}

--- a/base/features/java/skeleton/maven-build/pom.xml
+++ b/base/features/java/skeleton/maven-build/pom.xml
@@ -12,6 +12,7 @@
                     <configuration>
                         <source>${jdk.version}</source>
                         <target>${jdk.version}</target>
+                        <encoding>UTF-8</encoding>
                         <compilerArgs>
                             <arg>-parameters</arg>
                         </compilerArgs>


### PR DESCRIPTION
I found some encode issue when generated swagger.yml using openapi, so add utf-8 encode to java compile 