### PR TITLE
Fixed Typo the Spek feature's description

### DIFF
--- a/base/features/spek/feature.yml
+++ b/base/features/spek/feature.yml
@@ -1,4 +1,4 @@
-description: Adds support for the Spek testing framewokr
+description: Adds support for the Spek testing framework
 features:
     dependent:
       - kotlin


### PR DESCRIPTION
Simple typo `framewokr` => `framework`