### PR TITLE
Improved aws-api-gateway-graal feature targeting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ Micronaut Profiles
 This repository contains the profiles able to be used when creating Micronaut applications
 
 A profile is a set of application templates and commands that enable distinct development environments for the Micronaut framework.
+
+Build profiles
+===
+
+First, build micronaut CLI from source https://docs.micronaut.io/latest/guide/index.html#buildSource
+
+After that, clone https://github.com/micronaut-projects/micronaut-profiles side by side and execute:
+
+```bash
+./gradlew pTML
+```
+
+to build profiles. Then you should be able to do `mn create-app my-app --features your-features` to create an app.
+
+Every time you make a change to `micronaut-profiles` you need to do `./gradlew clean pTML` again

--- a/base/features/aws-api-gateway-graal/feature.yml
+++ b/base/features/aws-api-gateway-graal/feature.yml
@@ -11,4 +11,9 @@ dependencies:
     excludes:
       - group: com.fasterxml.jackson.module
         module: jackson-module-afterburner
+  - scope: compile
+    coords: io.micronaut.aws:micronaut-function-aws-api-proxy
+    excludes:
+      - group: com.fasterxml.jackson.module
+        module: jackson-module-afterburner
 

--- a/base/features/aws-api-gateway-graal/skeleton/README.md
+++ b/base/features/aws-api-gateway-graal/skeleton/README.md
@@ -6,16 +6,27 @@ The `Dockerfile` contains the build to build the native image and it can be buil
 
 ```bash
 $ docker build . -t @app.name@
-$ mkdir build
+$ mkdir -p build
 $ docker run --rm --entrypoint cat @app.name@  /home/application/function.zip > build/function.zip
 ```
 
-Which will add the function deployment ZIP file to `build/function.zip`. You can then deploy via the AWS console or CLI:
+Which will add the function deployment ZIP file to `build/function.zip`. You can run function locally using [SAM](https://github.com/awslabs/aws-sam-cli/)
+
+```bash
+$ docker build . -t @app.name@
+$ ./sam-local.sh
+```
+
+Or you can deploy it to AWS via the console or CLI:
 
 ```bash
 aws lambda create-function --function-name @app.name@ \
 --zip-file fileb://build/function.zip --handler function.handler --runtime provided \
---role arn:aws:iam::881337894647:role/lambda_basic_execution
+--role ARN_OF_LAMBDA_ROLE
+```
+
+To create role for AWS Lambda, use following code:
+```bash
 ```
 
 The function can be invoked by sending an API Gateway Proxy request. For example:
@@ -24,5 +35,13 @@ The function can be invoked by sending an API Gateway Proxy request. For example
 aws lambda invoke --function-name @app.name@ --payload '{"resource": "/{proxy+}", "path": "/ping", "httpMethod": "GET"}' build/response.txt
 cat build/response.txt
 ```
+
+and response should be something like:
+
+```json
+{"statusCode":200,"multiValueHeaders":{},"body":"{\"pong\":true, \"graal\": true}","isBase64Encoded":false}
+```
+
+Example controller responding with /ping are included in template.
 
 You should replace the `/ping` path entry with the URI the controller endpoint you wish to invoke.

--- a/base/features/aws-api-gateway-graal/skeleton/deploy.sh
+++ b/base/features/aws-api-gateway-graal/skeleton/deploy.sh
@@ -1,6 +1,19 @@
+#!/bin/sh
 docker build . -t @app.name@
-mkdir build
+mkdir -p build
 docker run --rm --entrypoint cat @app.name@  /home/application/function.zip > build/function.zip
-aws lambda create-function --function-name @app.name@ \
+
+# check for role
+ROLE_NAME=lambda-basic-role
+ROLE_ARN=`aws iam get-role --role-name ${ROLE_NAME} | grep Arn | cut -d'"' -f4`
+if [ "${ROLE_ARN}" == "" ]; then
+    echo "No role ${ROLE_NAME} exists!"
+    echo "Create one using: "
+    echo "> aws iam create-role --role-name ${ROLE_NAME} --assume-role-policy-document file://lambda-role-policy.json"
+    echo "> aws iam attach-role-policy --role-name ${ROLE_NAME} --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+    exit 1
+fi
+
+aws lambda create-function --function-name my-app \
 --zip-file fileb://build/function.zip --handler function.handler --runtime provided \
---role arn:aws:iam::881337894647:role/lambda_basic_execution
+--role ${ROLE_ARN}

--- a/base/features/aws-api-gateway-graal/skeleton/gradle-build/Dockerfile
+++ b/base/features/aws-api-gateway-graal/skeleton/gradle-build/Dockerfile
@@ -27,20 +27,7 @@ CMD ["/usr/lib/graalvm/bin/native-image"]
 FROM graalvm
 COPY --from=builder /home/application/ /home/application/
 WORKDIR /home/application
-RUN /usr/lib/graalvm/bin/java -cp build/libs/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
-RUN /usr/lib/graalvm/bin/native-image --no-server \
-             --class-path build/libs/@app.name@-*.jar \
-             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,build/reflect.json \
-             -H:EnableURLProtocols=http \
-             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
-             -H:Name=server \
-             -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime \
-             -H:+ReportUnsupportedElementsAtRuntime \
-             -H:-AllowVMInspection \
-             -H:-UseServiceLoaderFeature \
-             --allow-incomplete-classpath \
-             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
-             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom,com.sun.jndi.dns.DnsClient,io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler,com.amazonaws.serverless.proxy.internal.LambdaContainerHandler,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine
+RUN /home/application/build-native-image.sh
 RUN chmod 755 bootstrap
 RUN chmod 755 server
 RUN zip -j function.zip bootstrap server 

--- a/base/features/aws-api-gateway-graal/skeleton/gradle-build/build-native-image.sh
+++ b/base/features/aws-api-gateway-graal/skeleton/gradle-build/build-native-image.sh
@@ -1,8 +1,9 @@
-./gradlew assemble
-java -cp build/libs/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
-native-image --no-server \
+#!/bin/sh
+GRAALVM_HOME=${GRAALVM_HOME:-/usr/lib/graalvm}
+${GRAALVM_HOME}/bin/java -cp build/libs/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
+${GRAALVM_HOME}/bin/native-image --no-server \
              --class-path build/libs/@app.name@-*.jar \
-             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,build/reflect.json \
+             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,src/main/resources/netty-reflect.json,build/reflect.json \
              -H:EnableURLProtocols=http \
              -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
              -H:Name=server \
@@ -13,3 +14,4 @@ native-image --no-server \
              --allow-incomplete-classpath \
              --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
              --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom,com.sun.jndi.dns.DnsClient,io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler,com.amazonaws.serverless.proxy.internal.LambdaContainerHandler,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine
+

--- a/base/features/aws-api-gateway-graal/skeleton/lambda-role-policy.json
+++ b/base/features/aws-api-gateway-graal/skeleton/lambda-role-policy.json
@@ -1,0 +1,9 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": { "AWS" : "*" },
+        "Action": "sts:AssumeRole"
+    }]
+}
+

--- a/base/features/aws-api-gateway-graal/skeleton/maven-build/Dockerfile
+++ b/base/features/aws-api-gateway-graal/skeleton/maven-build/Dockerfile
@@ -27,20 +27,7 @@ CMD ["/usr/lib/graalvm/bin/native-image"]
 FROM graalvm
 COPY --from=builder /home/application/ /home/application/
 WORKDIR /home/application
-RUN /usr/lib/graalvm/bin/java -cp target/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer target/reflect.json
-RUN /usr/lib/graalvm/bin/native-image --no-server \
-             --class-path target/@app.name@-*.jar \
-             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,target/reflect.json \
-             -H:EnableURLProtocols=http \
-             -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
-             -H:Name=server \
-             -H:Class=io.micronaut.function.aws.runtime.MicronautLambdaRuntime \
-             -H:+ReportUnsupportedElementsAtRuntime \
-             -H:-AllowVMInspection \
-             -H:-UseServiceLoaderFeature \
-             --allow-incomplete-classpath \
-             --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
-             --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom,com.sun.jndi.dns.DnsClient,io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler,com.amazonaws.serverless.proxy.internal.LambdaContainerHandler,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine
+RUN /home/application/build-native-image.sh
 RUN chmod 755 bootstrap
 RUN chmod 755 server
 RUN zip -j function.zip bootstrap server

--- a/base/features/aws-api-gateway-graal/skeleton/maven-build/build-native-image.sh
+++ b/base/features/aws-api-gateway-graal/skeleton/maven-build/build-native-image.sh
@@ -1,8 +1,9 @@
-./mvnw package
-java -cp target/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer target/reflect.json
-native-image --no-server \
-             --class-path target/@app.name@-*.jar \
-             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,target/reflect.json \
+#!/bin/sh
+GRAALVM_HOME=${GRAALVM_HOME:-/usr/lib/graalvm}
+${GRAALVM_HOME}/bin/java -cp build/libs/@app.name@-*.jar io.micronaut.graal.reflect.GraalClassLoadingAnalyzer
+${GRAALVM_HOME}/bin/native-image --no-server \
+             --class-path build/libs/@app.name@-*.jar \
+             -H:ReflectionConfigurationFiles=src/main/resources/reflect.json,src/main/resources/netty-reflect.json,build/reflect.json \
              -H:EnableURLProtocols=http \
              -H:IncludeResources="logback.xml|application.yml|META-INF/services/*.*" \
              -H:Name=server \
@@ -13,3 +14,4 @@ native-image --no-server \
              --allow-incomplete-classpath \
              --rerun-class-initialization-at-runtime='sun.security.jca.JCAUtil$CachedSecureRandomHolder,javax.net.ssl.SSLContext' \
              --delay-class-initialization-to-runtime=io.netty.handler.codec.http.HttpObjectEncoder,io.netty.handler.codec.http.websocketx.WebSocket00FrameEncoder,io.netty.handler.ssl.util.ThreadLocalInsecureRandom,com.sun.jndi.dns.DnsClient,io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler,com.amazonaws.serverless.proxy.internal.LambdaContainerHandler,io.netty.handler.ssl.JdkNpnApplicationProtocolNegotiator,io.netty.handler.ssl.ReferenceCountedOpenSslEngine
+

--- a/base/features/aws-api-gateway-graal/skeleton/sam-local.sh
+++ b/base/features/aws-api-gateway-graal/skeleton/sam-local.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p build
+docker run --rm --entrypoint cat @app.name@  /home/application/function.zip > build/function.zip
+
+sam local start-api -t sam.yaml -p 3000
+

--- a/base/features/aws-api-gateway-graal/skeleton/sam.yaml
+++ b/base/features/aws-api-gateway-graal/skeleton/sam.yaml
@@ -8,7 +8,7 @@ Resources:
   MyServiceFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: example.StreamLambdaHandler::handleRequest
+      Handler: not.used.in.provided.runtime
       Runtime: provided
       CodeUri: build/function.zip
       MemorySize: 128

--- a/base/features/aws-api-gateway-graal/skeleton/src/main/java/@defaultPackage.path@/ExampleController.java
+++ b/base/features/aws-api-gateway-graal/skeleton/src/main/java/@defaultPackage.path@/ExampleController.java
@@ -1,0 +1,16 @@
+package my.app;
+
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.micronaut.http.annotation.*;
+
+@Controller("/")
+public class ExampleController {
+    private static final Logger LOG = LoggerFactory.getLogger(ExampleController.class);
+
+    @Get("/ping")
+    public String index() {
+        return "{\"pong\":true, \"graal\": true}";
+    }
+}

--- a/base/features/aws-api-gateway-graal/skeleton/src/main/resources/netty-reflect.json
+++ b/base/features/aws-api-gateway-graal/skeleton/src/main/resources/netty-reflect.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "io.netty.channel.socket.nio.NioServerSocketChannel",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.util.LinkedHashMap",
+    "methods": [
+      { "name": "<init>", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.util.ArrayList",
+    "allPublicMethods": true,
+    "allDeclaredConstructors": true
+  }
+]

--- a/base/features/aws-api-gateway-graal/skeleton/src/main/resources/reflect.json
+++ b/base/features/aws-api-gateway-graal/skeleton/src/main/resources/reflect.json
@@ -42,4 +42,8 @@
   "name" : "com.amazonaws.serverless.proxy.model.MultiValuedTreeMap",
   "allPublicMethods" : true,
   "allDeclaredConstructors" : true
+}, {
+  "name" : "io.micronaut.http.client.ServiceHttpClientCondition",
+  "allPublicMethods" : true,
+  "allDeclaredConstructors" : true
 }]


### PR DESCRIPTION
Based on recent [experience](https://github.com/micronaut-projects/micronaut-aws/issues/6#issuecomment-463391780) with improving code of graal native compiled micronaut example, here is improvements to micronaut CLI code generation profile:

  - Added basic commands for building profiles
  - More reflect files
  - Added example /ping controller
  - Added script for running function locally via sam
  - Using the same build-native-image.sh inside Dockerfile
  - Trying to read ARN of role to create Lambda with or show error with explanation how to create role
  - Improved documentation and dependencies


