### PR TITLE
Adding support for micrometer-cloudwatch feature

### DIFF
--- a/base/features/micrometer-cloudwatch/feature.yml
+++ b/base/features/micrometer-cloudwatch/feature.yml
@@ -1,0 +1,9 @@
+description: Adds support for Micrometer metrics (w/ AWS Cloudwatch reporter)
+features:
+    dependent:
+      - management
+dependencies:
+    - scope: compile
+      coords: io.micronaut.configuration:micronaut-micrometer-core
+    - scope: compile
+      coords: io.micronaut.configuration:micronaut-micrometer-registry-cloudwatch

--- a/base/features/micrometer-cloudwatch/skeleton/src/main/resources/application.yml
+++ b/base/features/micrometer-cloudwatch/skeleton/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+micronaut:
+    metrics:
+        enabled: true
+        export:
+            cloudwatch:
+                enabled: true


### PR DESCRIPTION
Realized that I added support for micrometer cloudwatch in core but did not have a corresponding PR here. 