### PR TITLE
Fix #134 -Removed @Shared from http client since it is getting initialized in setup()

### DIFF
--- a/service/templates/groovy/ControllerSpec.groovy
+++ b/service/templates/groovy/ControllerSpec.groovy
@@ -18,7 +18,7 @@ class ${className}Spec extends Specification {
     @Inject
     EmbeddedServer embeddedServer
 
-    @Shared @AutoCleanup
+    @AutoCleanup
     RxHttpClient client
 
     void setup() {


### PR DESCRIPTION
Removed `@Shared` from `RxHttpClient client` since it is getting initialized in setup()