### PR TITLE
Add runtime dependencies to ZIP

### DIFF
--- a/base/features/aws-api-gateway/skeleton/gradle-build/build.gradle
+++ b/base/features/aws-api-gateway/skeleton/gradle-build/build.gradle
@@ -1,7 +1,8 @@
 task buildZip(type: Zip) {
-  from sourceSets.main.output
-  into('lib') {
-    from(configurations.compileClasspath)
-  }
+    from sourceSets.main.output
+    into('lib') {
+        from configurations.compileClasspath
+        from configurations.runtimeClasspath
+    }
 }
 shadowJar.dependsOn buildZip


### PR DESCRIPTION
Right now, only compile scoped dependencies/jars are added to to .zip file. 
This will add runtime scoped dependencies/jars to .zip file (e.g.: `runtime "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8"`)