### PR TITLE
Added initialize-at-buildtime to dockerfile for aws-api-gateway-graal. Fixes #162

### DIFF
--- a/base/features/aws-api-gateway-graal/skeleton/Dockerfile
+++ b/base/features/aws-api-gateway-graal/skeleton/Dockerfile
@@ -27,9 +27,9 @@ CMD ["/usr/lib/graalvm/bin/native-image"]
 FROM graalvm
 COPY --from=builder /home/application/ /home/application/
 WORKDIR /home/application
-RUN /usr/lib/graalvm/bin/native-image --no-server -cp @jarPath@ 
+RUN /usr/lib/graalvm/bin/native-image --initialize-at-build-time=com.amazonaws.serverless.proxy.model --no-server -cp @jarPath@
 RUN chmod 755 bootstrap
 RUN chmod 755 server
-RUN zip -j function.zip bootstrap server 
+RUN zip -j function.zip bootstrap server
 EXPOSE 8080
 ENTRYPOINT ["/home/application/server"]


### PR DESCRIPTION
https://github.com/micronaut-projects/micronaut-profiles/issues/162

#162 references https://github.com/micronaut-projects/micronaut-aws/issues/49

mn create-app my-app --features aws-api-gateway-graal

Run ./sam-local.sh before the fix and build fails.
Run ./sam-local.sh after fix, curl http://localhost:3000/ping and receive a successful response
