### PR TITLE
Remove duplicate Maven encoding configuration

### DIFF
--- a/base/features/java/skeleton/maven-build/pom.xml
+++ b/base/features/java/skeleton/maven-build/pom.xml
@@ -11,7 +11,6 @@
           <configuration>
             <source>${jdk.version}</source>
             <target>${jdk.version}</target>
-            <encoding>UTF-8</encoding>
             <compilerArgs>
               <arg>-parameters</arg>
             </compilerArgs>


### PR DESCRIPTION
It's not necessary to set the encoding configuration in the
`maven-compiler-plugin` because it takes the value from
`${project.build.sourceEncoding}` property that is set in file
`micronaut-profiles/base/skeleton/maven-build/pom.xml`

In Maven, configuration by properties use to be the preferred way.

You can see it in the official documentation:
[https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html)