### PR TITLE
Remove duplicate Maven compiler 'source' and 'target' version configuration

### DIFF
--- a/base/features/java/skeleton/maven-build/pom.xml
+++ b/base/features/java/skeleton/maven-build/pom.xml
@@ -7,10 +7,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
-
           <configuration>
-            <source>${jdk.version}</source>
-            <target>${jdk.version}</target>
             <compilerArgs>
               <arg>-parameters</arg>
             </compilerArgs>


### PR DESCRIPTION
In Maven is preferred to use the properties `${maven.compiler.source}` and
`${maven.compiler.target}` that are already set in file
`micronaut-profiles/base/skeleton/maven-build/pom.xml`

Maven official documentation:
[https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#source)