### PR TITLE
Use properties to configure Maven compiler plugin

### DIFF
--- a/configuration/features/java/skeleton/maven-build/pom.xml
+++ b/configuration/features/java/skeleton/maven-build/pom.xml
@@ -1,5 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <properties>
+    <maven.compiler.target>${jdk.version}</maven.compiler.target>
+    <maven.compiler.source>${jdk.version}</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
   <build>
     <pluginManagement>
       <plugins>
@@ -7,11 +13,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
-
           <configuration>
-            <source>${jdk.version}</source>
-            <target>${jdk.version}</target>
-            <encoding>UTF-8</encoding>
             <compilerArgs>
               <arg>-parameters</arg>
             </compilerArgs>


### PR DESCRIPTION
I'm sorry but I don't know exactly the purpose of this `pom.xml`, but I think is good idea to
apply the same Maven good practices than in my previous commits, so in Maven
use to be preferred to set the configuration values with properties.

In this commit all the properties used are officially supported by the Maven
compiler plugin
(https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html)

If you told me the purpose of `configuration/` directory and the this `pom.xml` I could try to improve my pull request.

Thanks any way! 