### PR TITLE
Update junit Maven feature

### DIFF
--- a/base/features/junit/skeleton/maven-build/pom.xml
+++ b/base/features/junit/skeleton/maven-build/pom.xml
@@ -7,11 +7,6 @@
 				<version>2.22.0</version>
 				<dependencies>
 					<dependency>
-						<groupId>org.junit.platform</groupId>
-						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>1.2.0</version>
-					</dependency>
-					<dependency>
 						<groupId>org.junit.jupiter</groupId>
 						<artifactId>junit-jupiter-engine</artifactId>
 						<version>5.5.0</version>

--- a/base/features/junit/skeleton/maven-build/pom.xml
+++ b/base/features/junit/skeleton/maven-build/pom.xml
@@ -5,19 +5,6 @@
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.0</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.junit.jupiter</groupId>
-						<artifactId>junit-jupiter-engine</artifactId>
-						<version>5.5.0</version>
-					</dependency>
-					<dependency>
-						<groupId>org.junit.vintage</groupId>
-						<artifactId>junit-vintage-engine</artifactId>
-						<version>5.5.0</version>
-					</dependency>
-				</dependencies>
-
 				<configuration>
 					<detail>true</detail>
 					<includes>


### PR DESCRIPTION
Remove deprecated `junit-platform-surefire-provider` and configure JUnit 5 following their team recommendations.

[https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven)