### PR TITLE
Move maven surefire configuration to pluginmanagement

### DIFF
--- a/base/features/junit/skeleton/maven-build/pom.xml
+++ b/base/features/junit/skeleton/maven-build/pom.xml
@@ -1,17 +1,20 @@
 <project>
 	<build>
-		<plugins>
-			<!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.0</version>
-				<configuration>
-					<detail>true</detail>
-					<includes>
-						<include>%regex[.*]</include>
-					</includes>
-				</configuration>
-			</plugin>
-		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<!-- JUnit 5 requires Surefire and Failsafe version 2.22.0 or higher -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.22.2</version>
+					<configuration>
+						<detail>true</detail>
+						<includes>
+							<include>%regex[.*]</include>
+						</includes>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>

--- a/base/features/junit/skeleton/maven-build/pom.xml
+++ b/base/features/junit/skeleton/maven-build/pom.xml
@@ -1,7 +1,8 @@
 <project>
 	<properties>
-		<!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
+		<!-- JUnit 5 requires Surefire and Failsafe version 2.22.0 or higher -->
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 	</properties>
 	<build>
 		<pluginManagement>
@@ -16,6 +17,19 @@
 							<include>%regex[.*]</include>
 						</includes>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-failsafe-plugin</artifactId>
+					<version>${maven-failsafe-plugin.version}</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>integration-test</goal>
+								<goal>verify</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/base/features/junit/skeleton/maven-build/pom.xml
+++ b/base/features/junit/skeleton/maven-build/pom.xml
@@ -1,12 +1,15 @@
 <project>
+	<properties>
+		<!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
+		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+	</properties>
 	<build>
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<!-- JUnit 5 requires Surefire and Failsafe version 2.22.0 or higher -->
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.2</version>
+					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
 						<detail>true</detail>
 						<includes>

--- a/base/features/spek/skeleton/maven-build/pom.xml
+++ b/base/features/spek/skeleton/maven-build/pom.xml
@@ -1,28 +1,37 @@
 <project>
+  <properties>
+    <!-- JUnit 5 requires Surefire and Failsafe version 2.22.0 or higher -->
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+  </properties>
   <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.1.0</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <includes>
-            <include>**/*Spec.*</include>
-            <include>**/*Test.*</include>
-          </includes>
-        </configuration>
-      </plugin>
-    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <includes>
+              <include>**/*Spec.*</include>
+              <include>**/*Test.*</include>
+            </includes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/base/features/spock/skeleton/maven-build/pom.xml
+++ b/base/features/spock/skeleton/maven-build/pom.xml
@@ -23,10 +23,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>

--- a/base/features/spock/skeleton/maven-build/pom.xml
+++ b/base/features/spock/skeleton/maven-build/pom.xml
@@ -1,8 +1,10 @@
 <project>
   <properties>
-    <junit-platform.version>1.2.0</junit-platform.version>
-    <jupiter.version>5.2.0</jupiter.version>
+    <!-- JUnit 5 requires Surefire and Failsafe version 2.22.0 or higher -->
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+    <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
   </properties>
+
   <pluginRepositories>
     <pluginRepository>
       <id>bintray</id>
@@ -18,11 +20,40 @@
   </pluginRepositories>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <detail>true</detail>
+            <includes>
+              <include>%regex[.*]</include>
+            </includes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
-      </plugin>
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
@@ -42,35 +73,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>${junit-platform.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${jupiter.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${jupiter.version}</version>
-          </dependency>
-        </dependencies>
-
-        <configuration>
-          <detail>true</detail>
-          <includes>
-            <include>%regex[.*]</include>
-          </includes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
-
 </project>


### PR DESCRIPTION
The `pluginManagement` is the preferred place to configure the plugins because is like the "metadata" configuration that will be inherited by all children.

Propagate the junit 5 Maven configuration to the other features pom.xml