### PR TITLE
Fix Java 11 option in Dockerfile

### DIFF
--- a/service/skeleton/Dockerfile
+++ b/service/skeleton/Dockerfile
@@ -1,4 +1,4 @@
 FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.1.13-alpine-slim
 COPY @jarPath@ @app.name@.jar
 EXPOSE 8080
-CMD java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -jar @app.name@.jar
+CMD java -Dcom.sun.management.jmxremote -noverify ${JAVA_OPTS} -jar @app.name@.jar


### PR DESCRIPTION
Since JDK 10, "-XX:+UnlockExperimentalVMOptions" and "-XX:+UseCGroupMemoryLimitForHeap" are useless.