### PR TITLE
Improve scripts for generating GraalVM native images for graal-native-image feature.

### DIFF
--- a/base/features/graal-native-image/skeleton/Dockerfile
+++ b/base/features/graal-native-image/skeleton/Dockerfile
@@ -1,10 +1,16 @@
-FROM oracle/graalvm-ce:19.0.0 as graalvm
+FROM oracle/graalvm-ce:19.1.1 as graalvm
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN native-image --no-server -cp @jarPath@
 
-FROM frolvlad/alpine-glibc
+# Using --static to statically link libc and enable execution in a scratch docker container
+RUN native-image --no-server --static -jar @jarPath@ @app.name@
+
+FROM scratch
 EXPOSE 8080
 COPY --from=graalvm /home/app/@app.name@ .
-ENTRYPOINT ["./@app.name@"]
+
+# Setting young generation size to 24 Mb via -Xmn24m.
+# Smaller values decrease memory footprint and throughput.
+# Higher values increase memory footprint and throughput. 
+ENTRYPOINT ["./@app.name@ -Xmn24m"]

--- a/base/features/graal-native-image/skeleton/image-build.sh
+++ b/base/features/graal-native-image/skeleton/image-build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+if [[ -z "${GRAALVM_HOME}" ]]; then
+  echo "Set the GRAALVM_HOME environment variable to the home directory of your GraalVM installation."
+  exit -1;
+fi
+
+DISABLE_COMPRESSED=""
+
+if [[ -z "native-image -H:PrintFlags= | grep 'UseCompressedReferences'" ]]; then
+  DISABLE_COMPRESSED="-H:-UseCompressedReferences"
+fi
+
+$GRAALVM_HOME/bin/native-image $DISABLE_COMPRESSED -jar @jarPath@ @app.name@
+
+echo
+echo
+echo "To run the resulting image with a young generation size of 24Mb and a maximum of 128Mb of memory:"
+echo "    $ ./@app.name@ -Xmn24m -Xmx128m"

--- a/base/features/graal-native-image/skeleton/load-test.sh
+++ b/base/features/graal-native-image/skeleton/load-test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Test script that measures requests per CPU second as well as requests per Megabyte second.
+N=10000
+# Sends N number of requests to localhost:8080 via curl. Modify according to your application.
+COMMAND="curl -s http://localhost:8080/?[1-$N] -o /dev/null"
+# Number of iterations
+ITER=10
+# Execute with maximum of 128 mb memory.
+./@app.name@ -Xmn24m -Xmx128m &
+MY_PID=$!
+LAST_TIME=0
+FORMAT_STRING="%10s %10s %10s %10s %10s\n"
+REAL_TIME_SUM=0
+i="1"
+while [ $i -lt $(($ITER + 1)) ]
+do
+  REAL_TIME=$({ time $COMMAND ; } 2>&1 | grep real | sed -E 's/[^0-9\]+//g' | sed 's/^0*//')
+  REAL_TIME_SUM=$(($REAL_TIME_SUM+$REAL_TIME))
+  CPU_TIME_TOTAL="$(ps -p $MY_PID -o 'time=' | awk -F'[:.]+' '{t=$3*10+1000*($2+60*$1); print t}')"
+  CPU_TIME=$((CPU_TIME_TOTAL - LAST_TIME))
+  LAST_TIME=$CPU_TIME_TOTAL
+  RSS=$(ps -p $MY_PID -o 'rss=')
+  RSS=$(($RSS/1024))
+  MEMORY_MS=$(($RSS*$REAL_TIME/1000))
+  REQ_PER_S=$(($N*1000/$REAL_TIME))
+  REQ_PER_CPUS=$(($N*1000/$CPU_TIME))
+  REQ_PER_MBS=$(($N/$MEMORY_MS))
+  if [ "$i" -eq "1" ]; then
+    printf "$FORMAT_STRING" "n" "cpums" "req/cpus" "rss in mb" "req/mbs";
+  fi
+  printf "$FORMAT_STRING" $i $CPU_TIME $REQ_PER_CPUS $RSS $REQ_PER_MBS
+  i=$[$i+1]
+done
+MEMORY_MS=$(($RSS*$REAL_TIME_SUM/1000))
+REQ_PER_CPUS=$(($ITER*$N*1000/$CPU_TIME_TOTAL))
+REQ_PER_MBS=$(($ITER*$N/$MEMORY_MS))
+printf "$FORMAT_STRING" "TOTAL" $CPU_TIME_TOTAL $REQ_PER_CPUS $RSS $REQ_PER_MBS
+kill $MY_PID

--- a/base/features/graal-native-image/skeleton/pgo-and-image-build.sh
+++ b/base/features/graal-native-image/skeleton/pgo-and-image-build.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+if [[ -z "${GRAALVM_HOME}" ]]; then
+  echo "Set the GRAALVM_HOME environment variable to the home directory of your GraalVM installation."
+  exit -1;
+fi
+
+if [[ -z "native-image --help | grep 'pgo-instrument'" ]]; then
+  echo "Profile-guided optimizations require the GraalVM Enterprise Edition (EE)."
+  exit -1;
+fi
+
+echo "Building instrumented native image."
+$GRAALVM_HOME/bin/native-image -H:-UseCompressedReferences --pgo-instrument -jar @jarPath@ @app.name@
+
+echo "Exercising test workload to create profiles."
+./@app.name@ &
+
+echo "Sending 10000 requests to localhost:8080. Modify this test workload according to your application."
+curl -s http://localhost:8080/?[1-10000] -o /dev/null
+MY_PID=$!
+kill $MY_PID
+
+if [ ! -f ./default.iprof ]; then
+    echo "Error: File default.iprof with profile information could not be found."
+    exit -1;
+fi
+
+echo "Building final image taking the collected profile into account."
+$GRAALVM_HOME/bin/native-image -H:-UseCompressedReferences --pgo=default.iprof -jar @jarPath@ @app.name@
+
+echo
+echo
+echo "To run the resulting image with a young generation size of 24Mb and a maximum of 128Mb of memory:"
+echo "    $ ./@app.name@ -Xmn24m -Xmx128m"


### PR DESCRIPTION
This PR contains the following changes:
* Upgrade GraalVM version when using the docker-based image building to 19.1.1.
* A script image-build.sh for building images locally with the GraalVM installation as specified by the $GRAALVM_HOME environment variable.
* A script pgo-and-image-build.sh for creating images with high throughput performance with profile-guided optimizations.
* A script load-test.sh that serves as a simple local load generator that measures requests / cpu second as well as requests / megabyte second.
* Provide a flag to disable compressed references when using GraalVM EE as there are issues that prevent netty from working correctly in combination with compressed references.

Let me know if I should strip down the PR and put some of the elements elsewhere.

Also, please let me know how I can best test this via the "mn create-app" command. Currently, I just tested the script locally on an existing example. 

I can also prepare a PR to update the documentation at https://guides.micronaut.io/micronaut-creating-first-graal-app/guide/index.html with some description of the new options.

Here is some example output from the load generator scripts running the standard Micronaut GraalVM example in JVM mode versus native image mode:
```
$ ./load-test.sh "java -jar build/libs/complete-0.1.jar -Xmx64m"
17:04:28.131 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 1108ms. Server Running: http://localhost:8080
         n      cpums   req/cpus  rss in mb    req/mbs
         1      13690        730        303          4
         2       6840       1461        343         11
         3        920      10869        371         18
         4        850      11764        400         17
         5        860      11627        418         15
         6        810      12345        434         15
         7        850      11764        450         14
         8        950      10526        467         14
         9        810      12345        483         14
        10        810      12345        500         13
     TOTAL      27390       3650        500          9
17:04:47.842 [Thread-2] INFO  io.micronaut.runtime.Micronaut - Embedded Application shutting down
$ ./load-test.sh "./complete-ee-optimized -Xmx64m"
17:04:54.085 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 28ms. Server Running: http://localhost:8080
         n      cpums   req/cpus  rss in mb    req/mbs
         1       1000      10000         31        178
         2        970      10309         31        188
         3        970      10309         32        185
         4        980      10204         32        181
         5        980      10204         32        185
         6        960      10416         33        178
         7        990      10101         33        175
         8        990      10101         33        175
         9        980      10204         33        178
        10        980      10204         34        172
     TOTAL       9800      10204         34        170
```