### PR TITLE
Use scratch as base image

### DIFF
--- a/base/features/graal-native-image/skeleton/Dockerfile
+++ b/base/features/graal-native-image/skeleton/Dockerfile
@@ -2,9 +2,9 @@ FROM oracle/graalvm-ce:19.2.0.1 as graalvm
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN native-image --no-server -cp @jarPath@
+RUN native-image --no-server --static -cp @jarPath@
 
-FROM frolvlad/alpine-glibc
+FROM scratch
 EXPOSE 8080
 COPY --from=graalvm /home/app/@app.name@ .
 ENTRYPOINT ["./@app.name@"]


### PR DESCRIPTION
-  Create statically linked executable so binary don't need glibc