### PR TITLE
ehcache-profile

### DIFF
--- a/base/features/ehcache/feature.yml
+++ b/base/features/ehcache/feature.yml
@@ -1,0 +1,4 @@
+description: Adds support for Ecache (https://www.ehcache.org/)
+dependencies:
+  - scope: implementation
+    coords: io.micronaut.cache:micronaut-cache-ehcache

--- a/base/features/ehcache/feature.yml
+++ b/base/features/ehcache/feature.yml
@@ -1,4 +1,4 @@
-description: Adds support for Ecache (https://www.ehcache.org/)
+description: Adds support for Ehcache (https://www.ehcache.org/)
 dependencies:
   - scope: implementation
     coords: io.micronaut.cache:micronaut-cache-ehcache

--- a/base/features/ehcache/skeleton/src/main/resources/application.yml
+++ b/base/features/ehcache/skeleton/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+ehcache:
+  caches:
+    my-cache:
+      enabled: true
+
+

--- a/base/features/ehcache/skeleton/src/main/resources/application.yml
+++ b/base/features/ehcache/skeleton/src/main/resources/application.yml
@@ -2,5 +2,3 @@ ehcache:
   caches:
     my-cache:
       enabled: true
-
-


### PR DESCRIPTION
@alvarosanchez question:

 in the documentation we have this: https://micronaut-projects.github.io/micronaut-cache/snapshot/guide/#ehcache
it reads that the dependency is `compile 'org.ehcache:ehcache:3.8.0'`. I was thinking it should be `io.micronaut.cache:micronaut-cache-ehcache`, as the ehcache project here has a dependency already to the `'org.ehcache:ehcache:3.8.0'`.

in the profile i declared a dependency upon `io.micronaut.cache:micronaut-cache-ehcache`