### PR TITLE
Make Kotlin tests configurable for either Spek, Junit or KotlinTest testing frameworks

### DIFF
--- a/service/commands/create-controller.groovy
+++ b/service/commands/create-controller.groovy
@@ -33,20 +33,21 @@ render template: template("${lang}/Controller.${lang.extension}"),
         overwrite: overwrite
 
 def testFramework = config.testFramework
+String testFrameworkExtension = ""
 String testConvention = "Test"
 
-if (testFramework == "spock") {
+if (testFramework == "spock" || lang == SupportedLanguage.groovy) {
     testConvention = "Spec"
     lang = SupportedLanguage.groovy
-} else if (testFramework == "junit") {
-    lang = SupportedLanguage.java
-} else if (testFramework == "spek") {
+}
+if (testFramework == "spek") {
     lang = SupportedLanguage.kotlin
-} else if (lang == SupportedLanguage.groovy) {
-    testConvention = "Spec"
+}
+if (lang == SupportedLanguage.kotlin && (testFramework == "junit" || testFramework == "spek" )) {
+    testFrameworkExtension = testFramework.capitalize()
 }
 
-render template: template("${lang}/Controller${testConvention}.${lang.extension}"),
+render template: template("${lang}/Controller${testConvention}${testFrameworkExtension}.${lang.extension}"),
         destination: file("src/test/${lang}/${artifactPath}${testConvention}.${lang.extension}"),
         model: model,
         overwrite: overwrite

--- a/service/templates/kotlin/ControllerTest.kt
+++ b/service/templates/kotlin/ControllerTest.kt
@@ -13,3 +13,31 @@ class ${className}Test : Spek({
         //TODO:
     }
 })
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.BehaviorSpec
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.annotation.MicronautTest
+
+@MicronautTest
+class ${className}Test(private val embeddedServer: EmbeddedServer) : BehaviorSpec({
+
+    val specName = javaClass.simpleName
+
+    given("${className} server") {
+        val client: RxHttpClient = embeddedServer.applicationContext.createBean(RxHttpClient::class.java, embeddedServer.url)
+
+        `when`("a request is made to index") {
+            val response = client.toBlocking().exchange(
+                HttpRequest.GET<String>("/hello"), String::class.java)
+
+            then("the response is succesful") {
+                response.status shouldBe HttpStatus.OK
+            }
+        }
+    }
+})

--- a/service/templates/kotlin/ControllerTestJunit.kt
+++ b/service/templates/kotlin/ControllerTestJunit.kt
@@ -1,0 +1,18 @@
+${packageName ? 'package ' + packageName : '' }
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MicronautTest
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class ${className}Test(private val embeddedServer: EmbeddedServer) {
+
+    @Test
+    fun testIndex() {
+        val client: RxHttpClient = embeddedServer.applicationContext.createBean(RxHttpClient::class.java, embeddedServer.url)
+        assertEquals(HttpStatus.OK, client.toBlocking().exchange("/${propertyName}", String::class.java).status())
+    }
+}

--- a/service/templates/kotlin/ControllerTestSpek.kt
+++ b/service/templates/kotlin/ControllerTestSpek.kt
@@ -1,0 +1,21 @@
+${packageName ? 'package ' + packageName : '' }
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.test.annotation.MicronautTest
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.junit.Assert.assertEquals
+
+class ${className}Test(private val embeddedServer: EmbeddedServer) : Spek({
+
+    describe("/${propertyName}") {
+        val client: RxHttpClient = embeddedServer.applicationContext.createBean(RxHttpClient::class.java, embeddedServer.url)
+
+        it ("responds on endpoints /${propertyName}") {
+            assertEquals(HttpStatus.OK, client.toBlocking().exchange("/${propertyName}", String::class.java).status())
+        }
+    }
+})


### PR DESCRIPTION
@ZacharyKlein @jameskleeh @graemerocher 

The goal of this PR is to make Kotlin tests more configurable. A Kotlin application (unless specified otherwise through `--lang groovy|java` option) will now always generate a Kotlin test (and not a Java test). The implementation of the test depends on the testing framework specified when creating the app.

Examples:

```shell
# Simple Kotlin app without specific feature
mn create-app myapp --lang kotlin
cd myapp/
mn create-controller Hello
==> Creates a KotlinTest controller test extending KotlinTest BehaviorSpec

# Kotlin app with Junit
mn create-app myapp --lang kotlin --features junit
cd myapp/
mn create-controller Hello
==> Creates a classical JUnit controller test with @Test test

# Kotlin app with Spek
mn create-app myapp --lang kotlin --features spek
cd myapp/
mn create-controller Hello
==> Creates a Spek controller test extending Spek class
```

On a side note, test code generation for Java and Groovy has also been modified so that :
* Java apps will always generate JUnit controller tests
* Groovy apps will always generate Spock controller tests
... as they are the only ones for which we currently provide templates.

**Note**: I couldn't test this PR yet as I am currently not able to compile `micronaut-core` but working on it 🙂 