### PR TITLE
Switch back to alpine-glibc and include libsunec

### DIFF
--- a/base/features/graal-native-image/skeleton/Dockerfile
+++ b/base/features/graal-native-image/skeleton/Dockerfile
@@ -2,9 +2,10 @@ FROM oracle/graalvm-ce:19.2.1 as graalvm
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN native-image --no-server --static -cp @jarPath@
+RUN native-image --no-server -cp @jarPath@
 
-FROM scratch
+FROM frolvlad/alpine-glibc
 EXPOSE 8080
-COPY --from=graalvm /home/app/@app.name@ .
-ENTRYPOINT ["./@app.name@"]
+COPY --from=graalvm /opt/graalvm-ce-19.2.1/jre/lib/amd64/libsunec.so /app/libsunec.so
+COPY --from=graalvm /home/app/@app.name@/@app.name@ /app/@app.name@
+ENTRYPOINT ["/app/@app.name@", "-Djava.library.path=/app"]


### PR DESCRIPTION
I'm reverting the changes done in #183 and switch back to `alpine-glibc`. Now the applications that run in Docker start with `libsunec.so` available.

While trying to deploy a Micronaut app to AWS Lambda as a function I've discovered that if the application calls a 3rd party API using HTTPS, then `libsunec.so` needs to be present or otherwise it doesn't work and the container dies. That currently doesn't work when using `--static` and `scratch` as a base image.
In Graal `20.0.0-dev` they include by default `libsunec`. Actually I build the native-image apps for our test suite now with `--static`. For example, for the JWT security app: https://github.com/micronaut-graal-tests/micronaut-security-jwt-graal/commit/8b3ecd4a42db44cf0882480a4e15a195561a616f

Once GraalVM 20.0.0 is out I'll revisit this so we may go back again to `scratch` base image but in the mean time we can't.