### PR TITLE
fixes issues with running spock tests when using a maven build

### DIFF
--- a/base/features/kotlin/feature.yml
+++ b/base/features/kotlin/feature.yml
@@ -1,7 +1,4 @@
 description: Creates a Kotlin application
-features:
-    dependent:
-      - kotlintest
 build:
     plugins:
         - org.jetbrains.kotlin.jvm:1.3.50

--- a/base/features/kotlin/skeleton/maven-build/pom.xml
+++ b/base/features/kotlin/skeleton/maven-build/pom.xml
@@ -1,6 +1,7 @@
 <project>
   <properties>
     <kotlinVersion>1.3.50</kotlinVersion>
+    <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
   </properties>
   <build>
     <plugins>
@@ -9,6 +10,7 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <version>${kotlinVersion}</version>
         <configuration>
+          <jvmTarget>${kotlin.compiler.jvmTarget}</jvmTarget>
           <compilerPlugins>
             <plugin>all-open</plugin>
           </compilerPlugins>

--- a/base/features/spock/feature.yml
+++ b/base/features/spock/feature.yml
@@ -15,4 +15,4 @@ dependencies:
   - scope: testCompile
     coords: io.micronaut.test:micronaut-test-junit5
   - scope: testRuntimeOnly
-    coords: org.junit.vintage:junit-vintage-engine:5.5.0
+    coords: org.junit.vintage:junit-vintage-engine:5.5.2

--- a/base/features/spock/skeleton/maven-build/pom.xml
+++ b/base/features/spock/skeleton/maven-build/pom.xml
@@ -19,6 +19,16 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencies>
+    <!-- This is only required when running spock tests using maven -->
+    <!-- Version is 5.4.2 as the latest 5.5.2 does not recognize spock tests for some reason -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.4.2</version>
+    </dependency>
+  </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
this provides fix's for issues mentioned in this thread https://github.com/micronaut-projects/micronaut-test/issues/90. Once merged you will be able to create a java/spock/maven, groovy/spock/maven, and kotlin/spock/maven app and be able to execute tests as expected.

While not a true dependency as this will take care of adding the correct dependencies and version to the build, test generation may not be 100% correct until PR https://github.com/micronaut-projects/micronaut-profiles/pull/196 and PR https://github.com/micronaut-projects/micronaut-profiles/pull/198 have been merged (which those should be merged first if possible)

There were several issues going on here.

- junit-vintage had been added for gradle builds but not maven
        - added junit-vintage dependency for maven - important note this is version 5.4.2 as there seems to be issues with version 5.5.2. If using 5.5.2 it does not recognize that any tests are present and it throws an error
        - updated gradle dependency to latest

- added `kotlin.compiler.jvmTarget` for `kotlin-maven-plugin` plugin
        - ran into an issue where kotlin does not respect the compiler version and requires it to be explicitly set when defaulting to kotlintest

- removed the auto dependency of including the kotlintest feature by default when specifying the kotlin language
        - having this auto included feature was resulting in having duplicate `maven-surefire-plugin` blocks in the generated pom when specifying spock.
        - in order generate a default kotlin app with default tests you will now run ```mn create-app com.org.my-app -f kotlintest -b maven``` instead of ```mn create-app com.org.my-app -l kotlin -b maven```

- remaining non-breaking issue: when creating an app using ```mn create-app com.org.my-app -f kotlintest -b maven``` you will still end up with a duplicate `maven-surefire-plugin` which will trigger warnings but it will still execute.