### PR TITLE
updating generative gradle version

### DIFF
--- a/base/features/application/feature.yml
+++ b/base/features/application/feature.yml
@@ -1,5 +1,5 @@
 description: Facilitates creating an executable JVM application and adds support for creating fat/uber JARs
 build:
     plugins:
-        - com.github.johnrengelman.shadow:5.0.0
+        - com.github.johnrengelman.shadow:5.2.0
         - application

--- a/base/skeleton/gradle-build/gradle/wrapper/gradle-wrapper.properties
+++ b/base/skeleton/gradle-build/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/function-aws-alexa/profile.yml
+++ b/function-aws-alexa/profile.yml
@@ -11,7 +11,7 @@ skeleton:
 
 build:
     plugins:
-        - com.github.johnrengelman.shadow:5.0.0
+        - com.github.johnrengelman.shadow:5.2.0
         - jp.classmethod.aws.lambda:0.39
 dependencies:
   - scope: runtimeOnly

--- a/function-aws/profile.yml
+++ b/function-aws/profile.yml
@@ -11,7 +11,7 @@ skeleton:
 
 build:
     plugins:
-        - com.github.johnrengelman.shadow:5.0.0 
+        - com.github.johnrengelman.shadow:5.2.0
         - jp.classmethod.aws.lambda:0.39
 dependencies:
   - scope: excludes


### PR DESCRIPTION
When generating new Micronaut apps gradlew version will now be 6.0.1 as per https://github.com/micronaut-projects/micronaut-core/issues/2347 once this PR has merged. 