### PR TITLE
Update graal to 19.3.0

### DIFF
--- a/base/features/graal-native-image-kotlin/feature.yml
+++ b/base/features/graal-native-image-kotlin/feature.yml
@@ -1,0 +1,9 @@
+description: Allows Building a Native Image for Kotlin
+features:
+  dependent:
+    - kotlin
+dependencies:
+  - scope: kapt
+    coords: io.micronaut:micronaut-graal
+  - scope: compileOnly
+    coords: org.graalvm.nativeimage:svm

--- a/base/features/graal-native-image-kotlin/skeleton/Dockerfile
+++ b/base/features/graal-native-image-kotlin/skeleton/Dockerfile
@@ -1,0 +1,12 @@
+FROM oracle/graalvm-ce:19.3.0-java8 as graalvm
+#FROM oracle/graalvm-ce:19.3.0-java11 as graalvm # For JDK 11
+COPY . /home/app/@app.name@
+WORKDIR /home/app/@app.name@
+RUN gu install native-image
+RUN yum install -y libstdc++-static
+RUN native-image --no-server --static -cp @jarPath@
+
+FROM frolvlad/alpine-glibc
+EXPOSE 8080
+COPY --from=graalvm /home/app/@app.name@/@app.name@ /app/@app.name@
+ENTRYPOINT ["/app/@app.name@", "-Djava.library.path=/app"]

--- a/base/features/graal-native-image-kotlin/skeleton/Dockerfile
+++ b/base/features/graal-native-image-kotlin/skeleton/Dockerfile
@@ -3,7 +3,6 @@ FROM oracle/graalvm-ce:19.3.0-java8 as graalvm
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN yum install -y libstdc++-static
 RUN native-image --no-server --static -cp @jarPath@
 
 FROM frolvlad/alpine-glibc

--- a/base/features/graal-native-image-kotlin/skeleton/docker-build.sh
+++ b/base/features/graal-native-image-kotlin/skeleton/docker-build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+docker build . -t @app.name@
+echo
+echo
+echo "To run the docker container execute:"
+echo "    $ docker run -p 8080:8080 @app.name@"

--- a/base/features/graal-native-image-kotlin/skeleton/src/main/resources/META-INF/native-image/@defaultPackage@/@app.name@-application/native-image.properties
+++ b/base/features/graal-native-image-kotlin/skeleton/src/main/resources/META-INF/native-image/@defaultPackage@/@app.name@-application/native-image.properties
@@ -1,0 +1,3 @@
+Args = -H:IncludeResources=logback.xml|application.yml|bootstrap.yml \
+       -H:Name=@app.name@ \
+       -H:Class=@defaultPackage@.Application

--- a/base/features/graal-native-image/feature.yml
+++ b/base/features/graal-native-image/feature.yml
@@ -1,6 +1,6 @@
-description: Allows Building a Native Image
+description: Allows Building a Native Image for Java
 dependencies:
   - scope: annotationProcessor
     coords: io.micronaut:micronaut-graal
   - scope: compileOnly
-    coords: com.oracle.substratevm:svm
+    coords: org.graalvm.nativeimage:svm

--- a/base/features/graal-native-image/skeleton/Dockerfile
+++ b/base/features/graal-native-image/skeleton/Dockerfile
@@ -3,7 +3,6 @@ FROM oracle/graalvm-ce:19.3.0-java8 as graalvm
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN yum install -y libstdc++-static
 RUN native-image --no-server --static -cp @jarPath@
 
 FROM frolvlad/alpine-glibc

--- a/base/features/graal-native-image/skeleton/Dockerfile
+++ b/base/features/graal-native-image/skeleton/Dockerfile
@@ -1,11 +1,12 @@
-FROM oracle/graalvm-ce:19.2.1 as graalvm
+FROM oracle/graalvm-ce:19.3.0-java8 as graalvm
+#FROM oracle/graalvm-ce:19.3.0-java11 as graalvm # For JDK 11
 COPY . /home/app/@app.name@
 WORKDIR /home/app/@app.name@
 RUN gu install native-image
-RUN native-image --no-server -cp @jarPath@
+RUN yum install -y libstdc++-static
+RUN native-image --no-server --static -cp @jarPath@
 
 FROM frolvlad/alpine-glibc
 EXPOSE 8080
-COPY --from=graalvm /opt/graalvm-ce-19.2.1/jre/lib/amd64/libsunec.so /app/libsunec.so
 COPY --from=graalvm /home/app/@app.name@/@app.name@ /app/@app.name@
 ENTRYPOINT ["/app/@app.name@", "-Djava.library.path=/app"]


### PR DESCRIPTION
This PR should be merged with https://github.com/micronaut-projects/micronaut-core/pull/2418

- Update the profiles to GraalVM 19.3.0
- Create a new feature for Kotlin so `micronaut-graal` is in kapt scope instead of annotationProcessor. This fixes https://github.com/micronaut-projects/micronaut-core/issues/2336