### PR TITLE
adding ability to select log4j2 feature when using gradle

### DIFF
--- a/base/features/log4j2/feature.yml
+++ b/base/features/log4j2/feature.yml
@@ -1,0 +1,11 @@
+description: Adds Log4j2 Logging
+features:
+  excludes:
+    - logback
+dependencies:
+  - scope: implementation
+    coords: org.apache.logging.log4j:log4j-core:2.12.1
+  - scope: runtimeOnly
+    coords: org.apache.logging.log4j:log4j-api:2.12.1
+  - scope: runtimeOnly
+    coords: org.apache.logging.log4j:log4j-slf4j-impl:2.12.1

--- a/base/features/log4j2/skeleton/src/main/resources/log4j2.xml
+++ b/base/features/log4j2/skeleton/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="LogToConsole" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="@defaultPackage@" level="debug" additivity="false">
+            <AppenderRef ref="LogToConsole"/>
+        </Logger>
+        <Root level="error">
+            <AppenderRef ref="LogToConsole"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
you can now use the log4j2 feature with gradle builds `mn create-app test-app -f log4j2`. This adds the necessary dependencies and the configuration file `log4j2.xml`. The log4j-core dependency needs to be `implementation` otherwise the generated apps will not build.

There is some difference in using log4j2 when building with maven `mn create-app test-app -f log4j2 -b maven`. Everything is generated correctly (correct dependencies and log4j2.xml) and if you do a `./mvnw clean install` you can see that it is using the log4j2 config but when creating a controller and trying to add logging it does not behave the same way as it does when built with gradle. In example when building with gradle and adding a logger to the controller this import works `import org.apache.logging.log4j.Logger;` but when building with maven its `import org.apache.logging.log4j.core.Logger;` so just be aware that usage may be somewhat different and I am uncertain as to why.