### PR TITLE
Provider.name should be "openfaas" instead of "faas"

### DIFF
--- a/function/features/openfaas/skeleton/function.yml
+++ b/function/features/openfaas/skeleton/function.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 functions:
   @app.name@:


### PR DESCRIPTION
According to the documentation, the provider name should be `openfaas` and not `faas`: https://docs.openfaas.com/reference/yaml/